### PR TITLE
Enhancement/no strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1047 @@
+
+# Created by https://www.gitignore.io/api/vim,osx,linux,emacs,nanoc,eclipse,windows,intellij,jetbrains,sublimetext,intellij+iml,intellij+all,jetbrains+iml,jetbrains+all,microsoftoffice,exercism,visualstudio,visualstudiocode,openframeworks+visualstudio,go
+# Edit at https://www.gitignore.io/?templates=vim,osx,linux,emacs,nanoc,eclipse,windows,intellij,jetbrains,sublimetext,intellij+iml,intellij+all,jetbrains+iml,jetbrains+all,microsoftoffice,exercism,visualstudio,visualstudiocode,openframeworks+visualstudio,go
+
+### Eclipse ###
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+### Eclipse Patch ###
+# Eclipse Core
+.project
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Annotation Processing
+.apt_generated
+
+.sts4-cache/
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+
+
+### Exercism ###
+# gitignore template for Exercism project
+# website: https://exercism.io/
+
+# Ignore .exercism folder which contain sensitive data
+.exercism
+
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+### Go Patch ###
+/vendor/
+/Godeps/
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+# JetBrains templates
+**___jb_tmp___
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+# JetBrains templates
+
+### Intellij+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+
+### Intellij+iml ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+# JetBrains templates
+
+### Intellij+iml Patch ###
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+
+### JetBrains ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+# JetBrains templates
+
+### JetBrains Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+
+### JetBrains+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+# JetBrains templates
+
+### JetBrains+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+
+# Sonarlint plugin
+
+### JetBrains+iml ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+# JetBrains templates
+
+### JetBrains+iml Patch ###
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+
+### Linux ###
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### MicrosoftOffice ###
+
+# Word temporary
+~$*.doc*
+
+# Word Auto Backup File
+Backup of *.doc*
+
+# Excel temporary
+~$*.xls*
+
+# Excel Backup File
+*.xlk
+
+# PowerPoint temporary
+~$*.ppt*
+
+# Visio autosave temporary files
+*.~vsd*
+
+### Nanoc ###
+# For projects using Nanoc (http://nanoc.ws/)
+
+# Default location for output (needs to match output_dir's value found in nanoc.yaml)
+output/
+
+# Temporary file directory
+tmp/nanoc/
+
+# Crash Log
+crash.log
+
+### OpenFrameworks+VisualStudio ###
+# ignore generated binaries
+# but not the data folder
+
+/bin/*
+!/bin/data/
+
+# general
+
+[Bb]uild/
+[Oo]bj/
+*.o
+[Dd]ebug*/
+[Rr]elease*/
+*.mode*
+*.app/
+*.pyc
+.svn/
+*.log
+
+# IDE files which should
+# be ignored
+
+# XCode
+*.pbxuser
+*.perspective
+*.perspectivev3
+*.mode1v3
+*.mode2v3
+# XCode 4
+xcuserdata
+*.xcworkspace
+
+# Code::Blocks
+*.depend
+*.layout
+
+# Visual Studio
+*.sdf
+*.opensdf
+*.suo
+*.pdb
+*.ilk
+*.aps
+ipch/
+
+# Eclipse
+.externalToolBuilders
+
+# operating system
+
+# Linux
+# KDE
+.AppleDouble
+
+# OSX
 .DS_Store
+# Thumbnails
+._*
+
+# Windows
+# Image file caches
+Thumbs.db
+# Folder config file
+Desktop.ini
+
+# Android
+.csettings
+
+### OpenFrameworks+VisualStudio Patch ###
+.vs/
+*.ncb
+*.opendb
+*.cachefile
+*.VC.db
+*.VC.VC.opendb
+*.psess
+*.vsp
+*.vspx
+*.sap
+
+### OSX ###
+# General
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### SublimeText ###
+# Cache files for Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# Workspace files are user-specific
+*.sublime-workspace
+
+# Project files should be checked into the repository, unless a significant
+# proportion of contributors will probably not be using Sublime Text
+# *.sublime-project
+
+# SFTP configuration file
+sftp-config.json
+
+# Package control specific files
+Package Control.last-run
+Package Control.ca-list
+Package Control.ca-bundle
+Package Control.system-ca-bundle
+Package Control.cache/
+Package Control.ca-certs/
+Package Control.merged-ca-bundle
+Package Control.user-ca-bundle
+oscrypto-ca-bundle.crt
+bh_unicode_properties.cache
+
+# Sublime-github package stores a github token in this file
+# https://packagecontrol.io/packages/sublime-github
+GitHub.sublime-settings
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+### Windows ###
+# Windows thumbnail cache files
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### VisualStudio ###
+## Ignore Visual Studio temporary files, build results, and
+## files generated by popular Visual Studio add-ons.
+##
+## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
+
+# User-specific files
+*.rsuser
+*.user
+*.userosscache
+*.sln.docstates
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs
+
+# Mono auto generated files
+mono_crash.*
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Ll]og/
+
+# Visual Studio 2015/2017 cache/options directory
+# Uncomment if you have tasks that create the project's static files in wwwroot
+#wwwroot/
+
+# Visual Studio 2017 auto generated files
+Generated\ Files/
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUNIT
+*.VisualState.xml
+TestResult.xml
+
+# Build Results of an ATL Project
+[Dd]ebugPS/
+[Rr]eleasePS/
+dlldata.c
+
+# Benchmark Results
+BenchmarkDotNet.Artifacts/
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# StyleCop
+StyleCopReport.xml
+
+# Files built by Visual Studio
+*_i.c
+*_p.c
+*_h.h
+*.meta
+*.obj
+*.iobj
+*.pch
+*.ipdb
+*.pgc
+*.pgd
+*.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp_proj
+*_wpftmp.csproj
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+
+# Chutzpah Test files
+_Chutzpah*
+
+# Visual C++ cache files
+
+# Visual Studio profiler
+
+# Visual Studio Trace Files
+*.e2e
+
+# TFS 2012 Local Workspace
+$tf/
+
+# Guidance Automation Toolkit
+*.gpState
+
+# ReSharper is a .NET coding add-in
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+
+# JustCode is a .NET coding add-in
+.JustCode
+
+# TeamCity is a build add-in
+_TeamCity*
+
+# DotCover is a Code Coverage Tool
+*.dotCover
+
+# AxoCover is a Code Coverage Tool
+.axoCover/*
+!.axoCover/settings.json
+
+# Visual Studio code coverage results
+*.coverage
+*.coveragexml
+
+# NCrunch
+_NCrunch_*
+.*crunch*.local.xml
+nCrunchTemp_*
+
+# MightyMoose
+*.mm.*
+AutoTest.Net/
+
+# Web workbench (sass)
+.sass-cache/
+
+# Installshield output folder
+[Ee]xpress/
+
+# DocProject is a documentation generator add-in
+DocProject/buildhelp/
+DocProject/Help/*.HxT
+DocProject/Help/*.HxC
+DocProject/Help/*.hhc
+DocProject/Help/*.hhk
+DocProject/Help/*.hhp
+DocProject/Help/Html2
+DocProject/Help/html
+
+# Click-Once directory
+publish/
+
+# Publish Web Output
+*.[Pp]ublish.xml
+*.azurePubxml
+# Note: Comment the next line if you want to checkin your web deploy settings,
+# but database connection strings (with potential passwords) will be unencrypted
+*.pubxml
+*.publishproj
+
+# Microsoft Azure Web App publish settings. Comment the next line if you want to
+# checkin your Azure Web App publish settings, but sensitive information contained
+# in these scripts will be unencrypted
+PublishScripts/
+
+# NuGet Packages
+*.nupkg
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
+
+# Microsoft Azure Build Output
+csx/
+*.build.csdef
+
+# Microsoft Azure Emulator
+ecf/
+rcf/
+
+# Windows Store app package directories and files
+AppPackages/
+BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
+*.appx
+*.appxbundle
+*.appxupload
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!?*.[Cc]ache/
+
+# Others
+ClientBin/
+~$*
+*.dbmdl
+*.dbproj.schemaview
+*.jfm
+*.pfx
+*.publishsettings
+orleans.codegen.cs
+
+# Including strong name files can present a security risk
+# (https://github.com/github/gitignore/pull/2483#issue-259490424)
+#*.snk
+
+# Since there are multiple workflows, uncomment next line to ignore bower_components
+# (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
+#bower_components/
+
+# RIA/Silverlight projects
+Generated_Code/
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+ServiceFabricBackup/
+*.rptproj.bak
+
+# SQL Server files
+*.mdf
+*.ldf
+*.ndf
+
+# Business Intelligence projects
+*.rdl.data
+*.bim.layout
+*.bim_*.settings
+*.rptproj.rsuser
+*- Backup*.rdl
+
+# Microsoft Fakes
+FakesAssemblies/
+
+# GhostDoc plugin setting file
+*.GhostDoc.xml
+
+# Node.js Tools for Visual Studio
+.ntvs_analysis.dat
+node_modules/
+
+# Visual Studio 6 build log
+*.plg
+
+# Visual Studio 6 workspace options file
+*.opt
+
+# Visual Studio 6 auto-generated workspace file (contains which files were open etc.)
+*.vbw
+
+# Visual Studio LightSwitch build output
+**/*.HTMLClient/GeneratedArtifacts
+**/*.DesktopClient/GeneratedArtifacts
+**/*.DesktopClient/ModelManifest.xml
+**/*.Server/GeneratedArtifacts
+**/*.Server/ModelManifest.xml
+_Pvt_Extensions
+
+# Paket dependency manager
+.paket/paket.exe
+paket-files/
+
+# FAKE - F# Make
+.fake/
+
+# CodeRush personal settings
+.cr/personal
+
+# Python Tools for Visual Studio (PTVS)
+__pycache__/
+
+# Cake - Uncomment if you are using it
+# tools/**
+# !tools/packages.config
+
+# Tabs Studio
+*.tss
+
+# Telerik's JustMock configuration file
+*.jmconfig
+
+# BizTalk build output
+*.btp.cs
+*.btm.cs
+*.odx.cs
+*.xsd.cs
+
+# OpenCover UI analysis results
+OpenCover/
+
+# Azure Stream Analytics local run output
+ASALocalRun/
+
+# MSBuild Binary and Structured Log
+*.binlog
+
+# NVidia Nsight GPU debugger configuration file
+*.nvuser
+
+# MFractors (Xamarin productivity tool) working folder
+.mfractor/
+
+# Local History for Visual Studio
+.localhistory/
+
+# BeatPulse healthcheck temp database
+healthchecksdb
+
+# Backup folder for Package Reference Convert tool in Visual Studio 2017
+MigrationBackup/
+
+# End of https://www.gitignore.io/api/vim,osx,linux,emacs,nanoc,eclipse,windows,intellij,jetbrains,sublimetext,intellij+iml,intellij+all,jetbrains+iml,jetbrains+all,microsoftoffice,exercism,visualstudio,visualstudiocode,openframeworks+visualstudio,go
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright 2018 Ian Spence
+Copyright 2019 Paul Nelson Baker
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 # Golang Pwned Passwords
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/ecnepsnai/go-pwnedpassword?style=flat-square)](https://goreportcard.com/report/github.com/ecnepsnai/go-pwnedpassword)
-[![Godoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](https://godoc.org/github.com/ecnepsnai/go-pwnedpassword)
-[![Releases](https://img.shields.io/github/release/ecnepsnai/go-pwnedpassword/all.svg?style=flat-square)](https://github.com/ecnepsnai/go-pwnedpassword/releases)
-[![LICENSE](https://img.shields.io/github/license/ecnepsnai/go-pwnedpassword.svg?style=flat-square)](https://github.com/ecnepsnai/go-pwnedpassword/blob/master/LICENSE)
+[![Go Report Card](https://goreportcard.com/badge/github.com/paul-nelson-baker/go-pwnedpassword?style=flat-square)](https://goreportcard.com/report/github.com/paul-nelson-baker/go-pwnedpassword)
+[![Godoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](https://godoc.org/github.com/paul-nelson-baker/go-pwnedpassword)
+[![Releases](https://img.shields.io/github/release/paul-nelson-baker/go-pwnedpassword/all.svg?style=flat-square)](https://github.com/paul-nelson-baker/go-pwnedpassword/releases)
+[![LICENSE](https://img.shields.io/github/license/paul-nelson-baker/go-pwnedpassword.svg?style=flat-square)](https://github.com/paul-nelson-baker/go-pwnedpassword/blob/master/LICENSE)
 
-A package to determine if a given password has been "pwned", meaning the password has been
-compromised and may be used in a credential stuffing type attack. This package makes use of
-the "pwned passwords" feature of "Have I Been Pwned"
-https://haveibeenpwned.com/, which was created by Troy Hunt.
+This package makes use of the "pwned passwords" API of ["Have I Been Pwned" https://haveibeenpwned.com/](https://haveibeenpwned.com/), which was created by [Troy Hunt](https://haveibeenpwned.com/About).
+
+This is a forked version of [ecnepsnai/go-pwnedpassword](https://github.com/ecnepsnai/go-pwnedpassword), which utilizes bytes slices instead of strings. The reason for this choice is for the safety of the password itself. We can clear a slice of bytes ourselves, but a string may accidently live longer than we intend it to causing the password to be leaked logically if we're not careful. Using byte slices mitigates this risk to some extent.
 
 # Installation
 
 ```
-go get "github.com/ecnepsnai/go-pwnedpassword/
+go get "github.com/paul-nelson-baker/go-pwnedpassword
 ```
 
 # Usage
@@ -21,19 +20,24 @@ go get "github.com/ecnepsnai/go-pwnedpassword/
 To check if a password has been compromised:
 
 ```golang
-import "github.com/ecnepsnai/go-pwnedpassword"
+import (
+    "golang.org/x/crypto/ssh/terminal"
+    "syscall"
+    pwn "github.com/paul-nelson-baker/go-pwnedpassword"
+)
 
-password := "Your Users Password"
-result, err := pwned.IsPwned(password)
-if err != nil {
+fmt.Print("Enter password: ")
+passwordBytes, _ := terminal.ReadPassword(int(syscall.Stdin))
+
+result, err := pwn.IsPwned(password)
+if err != nil || result == nil {
     // Something went wrong (probably couldn't contact the pwned password API)
 }
 
-if !result.Pwned {
-    // Password hasn't been seen before. Doesn't mean it's safe, just lucky.
+if result.Pwned {
+    fmt.Printf("Sorry, this has been pwnd %d times\n", result.TimesObserved)
 } else {
-    count := result.TimesObserved
-    // Password has been seen `count` times before.
+    fmt.Println("Cudos! This hasn't been pwnd, but be careful. It's not necessarily safe")
 }
 ```
 
@@ -43,7 +47,7 @@ If you want, you can also use `pwned.IsPwnedAsync` to check asynchronously:
 import "github.com/ecnepsnai/go-pwnedpassword"
 
 pwned.IsPwnedAsync(req.Password, func(result *pwned.Result, err error) {
-    if err != nil {
+    if err != nil || result == nil {
         // Something went wrong (probably couldn't contact the pwned password API)
     }
 

--- a/_example.go
+++ b/_example.go
@@ -1,0 +1,17 @@
+package main
+
+// Example taken from https://github.com/paul-nelson-baker/pauls-toolbox/blob/master/cmd/check-pwnd/check-pwnd.go
+
+func main() {
+	// Error handling omitted for brevity
+	// Allows user to enter password without exposing it to the console
+	fmt.Print("Enter password: ")
+	password, _ := terminal.ReadPassword(int(syscall.Stdin))
+	// Pass the bytes taken from the console directly to the IsPwned service
+	result, _ := pwn.IsPwned(password)
+	if result.Pwned {
+		fmt.Printf("Sorry, this has been pwnd %d times\n", result.TimesObserved)
+	} else {
+		fmt.Println("Cudos! This hasn't been pwnd, but be careful it's not necessarily safe")
+	}
+}

--- a/_example.go
+++ b/_example.go
@@ -1,17 +1,27 @@
 package main
 
 // Example taken from https://github.com/paul-nelson-baker/pauls-toolbox/blob/master/cmd/check-pwnd/check-pwnd.go
+import (
+	"fmt"
+	pwn "github.com/ecnepsnai/go-pwnedpassword"
+	"golang.org/x/crypto/ssh/terminal"
+	"syscall"
+)
 
 func main() {
 	// Error handling omitted for brevity
 	// Allows user to enter password without exposing it to the console
 	fmt.Print("Enter password: ")
-	password, _ := terminal.ReadPassword(int(syscall.Stdin))
+	passwordBytes, _ := terminal.ReadPassword(int(syscall.Stdin))
 	// Pass the bytes taken from the console directly to the IsPwned service
-	result, _ := pwn.IsPwned(password)
+	result, _ := pwn.IsPwned(&passwordBytes)
 	if result.Pwned {
 		fmt.Printf("Sorry, this has been pwnd %d times\n", result.TimesObserved)
 	} else {
-		fmt.Println("Cudos! This hasn't been pwnd, but be careful it's not necessarily safe")
+		fmt.Println("Cudos! This hasn't been pwnd, but be careful. It's not necessarily safe")
+	}
+	// Clear the bytes to ensure it's not left up to the GC to clean up and is done correctly
+	for i := 0; i < len(passwordBytes); i++ {
+		passwordBytes[i] = ' '
 	}
 }

--- a/_example.go
+++ b/_example.go
@@ -3,9 +3,10 @@ package main
 // Example taken from https://github.com/paul-nelson-baker/pauls-toolbox/blob/master/cmd/check-pwnd/check-pwnd.go
 import (
 	"fmt"
+	"syscall"
+
 	pwn "github.com/ecnepsnai/go-pwnedpassword"
 	"golang.org/x/crypto/ssh/terminal"
-	"syscall"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ecnepsnai/go-pwnedpassword
+
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ecnepsnai/go-pwnedpassword
 
 go 1.12
+
+require golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4 h1:ydJNl0ENAG67pFbB+9tfhiL2pYqLhfoaZFw/cjLhY4A=
+golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pwned.go
+++ b/pwned.go
@@ -39,9 +39,7 @@ func IsStringPwndAsync(password string, isPwndCallback IsPwndCallback) {
 
 // IsPwnedAsync will asynchronously check if the provided password has been pwned. Calls `isPwndCallback` with the result when finished.
 func IsPwnedAsync(password *[]byte, isPwndCallback IsPwndCallback) {
-	go func() {
-		isPwndCallback(IsPwned(password))
-	}()
+	go isPwndCallback(IsPwned(password))
 }
 
 // IsStringPwnd will synchronously check if the provided password has been pwned.

--- a/pwned.go
+++ b/pwned.go
@@ -29,15 +29,17 @@ type pwnedHash struct {
 	Range string
 }
 
-// IsStringPwnedAsync will asynchronously check if the provided password has been pwned. Calls `cb` with the result when finished.
-func IsStringPwndAsync(password string, cb func(*Result, error)) {
-	IsPwnedAsync([]byte(password), cb)
+type IsPwndCallback func(*Result, error)
+
+// IsStringPwnedAsync will asynchronously check if the provided password has been pwned. Calls `isPwndCallback` with the result when finished.
+func IsStringPwndAsync(password string, isPwndCallback IsPwndCallback) {
+	IsPwnedAsync([]byte(password), isPwndCallback)
 }
 
-// IsPwnedAsync will asynchronously check if the provided password has been pwned. Calls `cb` with the result when finished.
-func IsPwnedAsync(password []byte, cb func(*Result, error)) {
+// IsPwnedAsync will asynchronously check if the provided password has been pwned. Calls `isPwndCallback` with the result when finished.
+func IsPwnedAsync(password []byte, isPwndCallback IsPwndCallback) {
 	go func() {
-		cb(IsPwned(password))
+		isPwndCallback(IsPwned(password))
 	}()
 }
 

--- a/pwned.go
+++ b/pwned.go
@@ -12,6 +12,10 @@ import (
 	"strings"
 )
 
+var (
+	PwndApiHost = "https://api.pwnedpasswords.com"
+)
+
 // Result describes a result from the Pwned Password service.
 type Result struct {
 	// Pwned has the password been seen at least once. A value of false doesn't mean the password is any good though.
@@ -25,11 +29,21 @@ type pwnedHash struct {
 	Range string
 }
 
+// IsStringPwnedAsync will asynchronously check if the provided password has been pwned. Calls `cb` with the result when finished.
+func IsStringPwndAsync(password string, cb func(*Result, error)) {
+	IsPwnedAsync([]byte(password), cb)
+}
+
 // IsPwnedAsync will asynchronously check if the provided password has been pwned. Calls `cb` with the result when finished.
 func IsPwnedAsync(password []byte, cb func(*Result, error)) {
 	go func() {
 		cb(IsPwned(password))
 	}()
+}
+
+// IsStringPwnd will synchronously check if the provided password has been pwned.
+func IsStringPwnd(password string) (*Result, error) {
+	return IsPwned([]byte(password))
 }
 
 // IsPwned will synchronously check if the provided password has been pwned.
@@ -43,7 +57,8 @@ func IsPwned(password []byte) (*Result, error) {
 		return nil, err
 	}
 
-	resp, err := http.Get("https://api.pwnedpasswords.com/range/" + hash.Range)
+	requestUrl := fmt.Sprintf("%s/range/%s", PwndApiHost, hash.Range)
+	resp, err := http.Get(requestUrl)
 	if err != nil {
 		return nil, err
 	}

--- a/pwned.go
+++ b/pwned.go
@@ -33,11 +33,12 @@ type IsPwndCallback func(*Result, error)
 
 // IsStringPwnedAsync will asynchronously check if the provided password has been pwned. Calls `isPwndCallback` with the result when finished.
 func IsStringPwndAsync(password string, isPwndCallback IsPwndCallback) {
-	IsPwnedAsync([]byte(password), isPwndCallback)
+	bytes := []byte(password)
+	IsPwnedAsync(&bytes, isPwndCallback)
 }
 
 // IsPwnedAsync will asynchronously check if the provided password has been pwned. Calls `isPwndCallback` with the result when finished.
-func IsPwnedAsync(password []byte, isPwndCallback IsPwndCallback) {
+func IsPwnedAsync(password *[]byte, isPwndCallback IsPwndCallback) {
 	go func() {
 		isPwndCallback(IsPwned(password))
 	}()
@@ -45,12 +46,13 @@ func IsPwnedAsync(password []byte, isPwndCallback IsPwndCallback) {
 
 // IsStringPwnd will synchronously check if the provided password has been pwned.
 func IsStringPwnd(password string) (*Result, error) {
-	return IsPwned([]byte(password))
+	bytes := []byte(password)
+	return IsPwned(&bytes)
 }
 
 // IsPwned will synchronously check if the provided password has been pwned.
-func IsPwned(password []byte) (*Result, error) {
-	if len(password) == 0 {
+func IsPwned(password *[]byte) (*Result, error) {
+	if len(*password) == 0 {
 		return nil, fmt.Errorf("empty password provided")
 	}
 
@@ -103,9 +105,9 @@ func IsPwned(password []byte) (*Result, error) {
 	return &ret, nil
 }
 
-func getHash(password []byte) (*pwnedHash, error) {
+func getHash(password *[]byte) (*pwnedHash, error) {
 	h := sha1.New()
-	_, err := h.Write(password)
+	_, err := h.Write(*password)
 	if err != nil {
 		return nil, err
 	}

--- a/pwned_test.go
+++ b/pwned_test.go
@@ -10,7 +10,7 @@ import (
 func TestPositiveMatch(t *testing.T) {
 	t.Parallel()
 
-	rt, err := IsPwned("password")
+	rt, err := IsPwned([]byte("password"))
 	if err != nil {
 		t.Errorf("IsPwned() error = %s", err.Error())
 		return
@@ -29,9 +29,9 @@ func TestNegativeMatch(t *testing.T) {
 	t.Parallel()
 
 	// Generate Random Password
-	randB := make([]byte, 32)
-	rand.Read(randB)
-	password := base64.StdEncoding.EncodeToString(randB)
+	randBytes := make([]byte, 32)
+	_, _ = rand.Read(randBytes)
+	password := []byte(base64.StdEncoding.EncodeToString(randBytes))
 
 	rt, err := IsPwned(password)
 	if err != nil {
@@ -57,7 +57,7 @@ func TestAsync(t *testing.T) {
 	var result *Result
 	var err error
 
-	IsPwnedAsync("password", func(r *Result, e error) {
+	IsPwnedAsync([]byte("password"), func(r *Result, e error) {
 		result = r
 		err = e
 		wg.Done()
@@ -82,7 +82,7 @@ func TestAsync(t *testing.T) {
 func TestEmptyPassword(t *testing.T) {
 	t.Parallel()
 
-	_, err := IsPwned("")
+	_, err := IsPwned([]byte{})
 	if err == nil {
 		t.Errorf("No error seen when one expected")
 		return

--- a/pwned_test.go
+++ b/pwned_test.go
@@ -1,6 +1,7 @@
 package pwned
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/base64"
 	"sync"
@@ -28,12 +29,15 @@ func TestPositiveMatch(t *testing.T) {
 func TestNegativeMatch(t *testing.T) {
 	t.Parallel()
 
-	// Generate Random Password
+	// Generate random password and Base64 encode it for HTTP transfer
 	randBytes := make([]byte, 32)
 	_, _ = rand.Read(randBytes)
-	password := []byte(base64.StdEncoding.EncodeToString(randBytes))
+	var byteBuffer bytes.Buffer
+	encoder := base64.NewEncoder(base64.StdEncoding, &byteBuffer)
+	_, _ = encoder.Write(randBytes)
+	encodedRandomBytes := byteBuffer.Bytes()
 
-	rt, err := IsPwned(password)
+	rt, err := IsPwned(encodedRandomBytes)
 	if err != nil {
 		t.Errorf("IsPwned() error = %s", err.Error())
 		return

--- a/pwned_test.go
+++ b/pwned_test.go
@@ -11,7 +11,8 @@ import (
 func TestPositiveMatch(t *testing.T) {
 	t.Parallel()
 
-	rt, err := IsPwned([]byte("password"))
+	passwordBytes := []byte("password")
+	rt, err := IsPwned(&passwordBytes)
 	if err != nil {
 		t.Errorf("IsPwned() error = %s", err.Error())
 		return
@@ -37,7 +38,7 @@ func TestNegativeMatch(t *testing.T) {
 	_, _ = encoder.Write(randBytes)
 	encodedRandomBytes := byteBuffer.Bytes()
 
-	rt, err := IsPwned(encodedRandomBytes)
+	rt, err := IsPwned(&encodedRandomBytes)
 	if err != nil {
 		t.Errorf("IsPwned() error = %s", err.Error())
 		return
@@ -61,7 +62,8 @@ func TestAsync(t *testing.T) {
 	var result *Result
 	var err error
 
-	IsPwnedAsync([]byte("password"), func(r *Result, e error) {
+	passwordBytes := []byte("password")
+	IsPwnedAsync(&passwordBytes, func(r *Result, e error) {
 		result = r
 		err = e
 		wg.Done()
@@ -86,7 +88,7 @@ func TestAsync(t *testing.T) {
 func TestEmptyPassword(t *testing.T) {
 	t.Parallel()
 
-	_, err := IsPwned([]byte{})
+	_, err := IsPwned(&[]byte{})
 	if err == nil {
 		t.Errorf("No error seen when one expected")
 		return


### PR DESCRIPTION
Not entirely true. I've not removed the ability to use strings, but I've placed a preference on []byte. The reason it's "better" to use a []byte instead of a string is because we can directly control the lifespan of a byte array's contents while a string is immutable and could potentially live longer than we want it to in memory, which is dangerous for a password. A developer using the library is ultimately responsible for cleaning that data safely but this will help encourage that kind of safety.